### PR TITLE
feat: add qualifiers for Arg and Flag to disambiguate Cli.{Parsed.}Flag

### DIFF
--- a/Cli/Basic.lean
+++ b/Cli/Basic.lean
@@ -360,7 +360,7 @@ section Configuration
     -/
     structure Flag where
       /-- Associated flag meta-data. -/
-      flag  : Flag
+      flag  : Cli.Flag
       /-- Parsed value that was validated and conforms to `flag.type`. -/
       value : String
       deriving Inhabited, BEq, Repr
@@ -393,7 +393,7 @@ section Configuration
     -/
     structure Arg where
       /-- Associated argument meta-data. -/
-      arg   : Arg
+      arg   : Cli.Arg
       /-- Parsed value that was validated and conforms to `arg.type`. -/
       value : String
       deriving Inhabited, BEq, Repr


### PR DESCRIPTION
Thanks to https://github.com/leanprover/lean4/pull/5783, we now have recursive structure commands,
which trips the inference into constructing a recursive struct. Therefore, we disambiguate the fields in `Cli.Parsed.Flag` to explicitly refer to `Cli.Flag`.

Discovered when bumping toolchain to nightly in https://github.com/leanprover/LNSym/pull/244.