### PR TITLE
Bump lean to 4.15.0-rc1

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.14.0-rc1
+leanprover/lean4:v4.15.0-rc1


### PR DESCRIPTION
Not sure how you'd like to manage release tracking. I saw the last version is an rc so figured this would be ok!