### PR TITLE
build static library by default

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,6 +7,7 @@ experimental.module = true
 
 [[lean_lib]]
 name = "Cli"
+defaultFacets = ["static"]
 
 [[lean_lib]]
 name = "CliTest"


### PR DESCRIPTION
Pre-builds .c.o.export files so downstream executables can link without generating them on-demand.