### PR TITLE
v4.29.1

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.29.1


### PR DESCRIPTION
Create release / tag for latest stable toolchain:

https://github.com/leanprover/lean4/releases/tag/v4.29.1